### PR TITLE
refactor!: rework logging to accept log.Logger instead of using the debug flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ install_deps:
 	go mod download
 
 setup-test:
-	./testdata/setup_test_repos.sh
+	sh ./testdata/setup_test_repos.sh
 
 # Standard go test
 test:

--- a/pkg/branch_diff_commits_test.go
+++ b/pkg/branch_diff_commits_test.go
@@ -24,7 +24,7 @@ func TestBranchDiffCommits(t *testing.T) {
 
 func TestBranchDiffCommitsWithMasterMerge(t *testing.T) {
 	repo, _ := git.PlainOpen("../testdata/commits_on_branch")
-	testGit := &Git{repo: repo, Debug: true}
+	testGit := &Git{repo: repo}
 
 	commits, err := testGit.BranchDiffCommits("behind-master", "origin/master")
 

--- a/pkg/commit_test.go
+++ b/pkg/commit_test.go
@@ -1,6 +1,8 @@
 package history
 
 import (
+	"io/ioutil"
+	"log"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -10,7 +12,7 @@ func TestCommit(t *testing.T) {
 	repo := setupRepo()
 	createTestHistory(repo)
 
-	testGit := &Git{repo: repo}
+	testGit := &Git{repo: repo, DebugLogger: log.New(ioutil.Discard, "", 0)}
 
 	head, _ := testGit.CurrentCommit()
 

--- a/pkg/commits_between_test.go
+++ b/pkg/commits_between_test.go
@@ -1,6 +1,8 @@
 package history
 
 import (
+	"io/ioutil"
+	"log"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -10,7 +12,7 @@ import (
 
 func TestCommitsBetween(t *testing.T) {
 	repo, _ := git.PlainOpen("../testdata/git_tags")
-	testGit := &Git{repo: repo, Debug: false}
+	testGit := &Git{repo: repo, DebugLogger: log.New(ioutil.Discard, "", 0)}
 
 	head, err := repo.Head()
 
@@ -40,7 +42,7 @@ func TestNoToCommit(t *testing.T) {
 
 	head, _ := repo.Head()
 
-	testGit := &Git{repo: repo}
+	testGit := &Git{repo: repo, DebugLogger: log.New(ioutil.Discard, "", 0)}
 
 	commits, err := testGit.CommitsBetween(head.Hash(), plumbing.Hash{})
 

--- a/pkg/commits_on_branch.go
+++ b/pkg/commits_on_branch.go
@@ -2,7 +2,6 @@ package history
 
 import (
 	"errors"
-	"log"
 
 	"gopkg.in/src-d/go-git.v4"
 	"gopkg.in/src-d/go-git.v4/plumbing"
@@ -33,9 +32,7 @@ func (g *Git) CommitsOnBranch(
 	})
 
 	if branchIterErr != nil {
-		if g.Debug {
-			log.Printf("Stopped getting commits on branch: %v", branchIterErr)
-		}
+		g.DebugLogger.Printf("Stopped getting commits on branch: %v", branchIterErr)
 	}
 
 	return branchCommits, nil

--- a/pkg/current_commit.go
+++ b/pkg/current_commit.go
@@ -1,8 +1,6 @@
 package history
 
 import (
-	"fmt"
-
 	"gopkg.in/src-d/go-git.v4/plumbing/object"
 )
 
@@ -16,9 +14,7 @@ func (g *Git) CurrentCommit() (*object.Commit, error) {
 
 	currentCommitHash := head.Hash()
 
-	if g.Debug {
-		fmt.Printf("\ncurrent commitHash: %v \n", currentCommitHash)
-	}
+	g.DebugLogger.Printf("current commitHash: %v \n", currentCommitHash)
 
 	commitObject, err := g.repo.CommitObject(currentCommitHash)
 

--- a/pkg/current_commit_test.go
+++ b/pkg/current_commit_test.go
@@ -1,6 +1,8 @@
 package history
 
 import (
+	"io/ioutil"
+	"log"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -10,7 +12,7 @@ func TestCurrentCommit(t *testing.T) {
 	repo := setupRepo()
 	createTestHistory(repo)
 
-	testGit := &Git{repo: repo}
+	testGit := &Git{repo: repo, DebugLogger: log.New(ioutil.Discard, "", 0)}
 
 	currentCommit, err := testGit.CurrentCommit()
 

--- a/pkg/current_tag.go
+++ b/pkg/current_tag.go
@@ -2,7 +2,6 @@ package history
 
 import (
 	"errors"
-	"log"
 )
 
 var (
@@ -24,14 +23,10 @@ func (g *Git) CurrentTag() (*Tag, error) {
 		return nil, err
 	}
 
-	if g.Debug {
-		log.Println("head hash: ", head.Hash())
-	}
+	g.DebugLogger.Println("head hash: ", head.Hash())
 
 	for _, tag := range tags {
-		if g.Debug {
-			log.Printf("tag: %v, hash: %v", tag.Name, tag.Hash)
-		}
+		g.DebugLogger.Printf("tag: %v, hash: %v", tag.Name, tag.Hash)
 
 		if tag.Hash == head.Hash() {
 			return tag, nil

--- a/pkg/current_tag_test.go
+++ b/pkg/current_tag_test.go
@@ -1,15 +1,15 @@
 package history
 
 import (
+	"io/ioutil"
+	"log"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"gopkg.in/src-d/go-git.v4"
 )
 
 func TestCurrentTagHappy(t *testing.T) {
-	repo, err := git.PlainOpen("../testdata/git_tags")
-	testGit := &Git{repo: repo, Debug: true}
+	testGit, err := OpenGit("../testdata/git_tags", nil)
 
 	assert.NoError(t, err)
 
@@ -20,8 +20,7 @@ func TestCurrentTagHappy(t *testing.T) {
 }
 
 func TestCurrentTagAnnotatedHappy(t *testing.T) {
-	repo, err := git.PlainOpen("../testdata/annotated_git_tags_mix")
-	testGit := &Git{repo: repo, Debug: true}
+	testGit, err := OpenGit("../testdata/annotated_git_tags_mix", nil)
 
 	assert.NoError(t, err)
 
@@ -35,7 +34,7 @@ func TestCurrentTagUnhappy(t *testing.T) {
 	repo := setupRepo()
 	createTestHistory(repo)
 
-	testGit := &Git{repo: repo}
+	testGit := &Git{repo: repo, DebugLogger: log.New(ioutil.Discard, "", 0)}
 
 	_, err := testGit.CurrentTag()
 

--- a/pkg/get_tags.go
+++ b/pkg/get_tags.go
@@ -1,7 +1,6 @@
 package history
 
 import (
-	"log"
 	"sort"
 
 	"gopkg.in/src-d/go-git.v4"
@@ -24,9 +23,7 @@ func (g *Git) getTags() ([]*Tag, error) {
 		commitDate, err := g.commitDate(t.Hash())
 
 		if err != nil {
-			if g.Debug {
-				log.Printf("tag: %v ignored due to missing commit date: %v", t.Name(), err)
-			}
+			g.DebugLogger.Printf("tag: %v ignored due to missing commit date: %v", t.Name(), err)
 			return nil
 		}
 
@@ -53,11 +50,9 @@ func (g *Git) getTags() ([]*Tag, error) {
 	// Tags are alphabetically ordered. We need to sort them by date.
 	sortedTags := sortTags(g.repo, tags)
 
-	if g.Debug {
-		log.Println("Sorted tag output: ")
-		for _, taginstance := range sortedTags {
-			log.Printf("hash: %v time: %v", taginstance.Hash, taginstance.Date.UTC())
-		}
+	g.DebugLogger.Println("Sorted tag output: ")
+	for _, taginstance := range sortedTags {
+		g.DebugLogger.Printf("hash: %v time: %v", taginstance.Hash, taginstance.Date.UTC())
 	}
 
 	return sortedTags, nil

--- a/pkg/get_tags_test.go
+++ b/pkg/get_tags_test.go
@@ -4,12 +4,10 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"gopkg.in/src-d/go-git.v4"
 )
 
 func TestGetTags(t *testing.T) {
-	repo, err := git.PlainOpen("../testdata/git_tags")
-	testGit := &Git{repo: repo, Debug: false}
+	testGit, err := OpenGit("../testdata/git_tags", nil)
 
 	assert.NoError(t, err)
 
@@ -24,8 +22,7 @@ func TestGetTags(t *testing.T) {
 }
 
 func TestAnnotatedGetTags(t *testing.T) {
-	repo, err := git.PlainOpen("../testdata/annotated_git_tags_mix")
-	testGit := &Git{repo: repo, Debug: false}
+	testGit, err := OpenGit("../testdata/annotated_git_tags_mix", nil)
 
 	assert.NoError(t, err)
 

--- a/pkg/open_git.go
+++ b/pkg/open_git.go
@@ -1,23 +1,31 @@
 package history
 
 import (
+	"io/ioutil"
+	"log"
+
 	"gopkg.in/src-d/go-git.v4"
 )
 
 // Git is the struct used to house all methods in use in Commitsar.
 type Git struct {
 	repo *git.Repository
-	// Debug flag is passed to make debugging easier during development/problematic deploys
-	Debug bool
+	// DebugLogger flag is passed to make debugging easier during development/problematic deploys
+	DebugLogger *log.Logger
 }
 
 // OpenGit loads Repo on path and returns a new Git struct to work with.
-func OpenGit(path string, debug bool) (*Git, error) {
+func OpenGit(path string, debugLogger *log.Logger) (*Git, error) {
 	repo, repoErr := git.PlainOpen(path)
 
 	if repoErr != nil {
 		return nil, repoErr
 	}
 
-	return &Git{repo: repo, Debug: debug}, nil
+	// Failsafe for when debug logger is omitted
+	if debugLogger == nil {
+		return &Git{repo: repo, DebugLogger: log.New(ioutil.Discard, "", 0)}, nil
+	}
+
+	return &Git{repo: repo, DebugLogger: debugLogger}, nil
 }

--- a/pkg/open_git_test.go
+++ b/pkg/open_git_test.go
@@ -7,14 +7,12 @@ import (
 )
 
 func TestOpenGit(t *testing.T) {
-	git, err := OpenGit("../", true)
+	_, err := OpenGit("../", nil)
 
 	// Should not error if this git repository is valid
 	assert.NoError(t, err)
-	// Check that debug flag is passed correctly
-	assert.Equal(t, true, git.Debug)
 
-	_, unhappyErr := OpenGit(".", false)
+	_, unhappyErr := OpenGit(".", nil)
 
 	// Should error opening a folder with missing .git
 	assert.Error(t, unhappyErr)

--- a/pkg/previous_tag.go
+++ b/pkg/previous_tag.go
@@ -2,7 +2,6 @@ package history
 
 import (
 	"errors"
-	"log"
 
 	"gopkg.in/src-d/go-git.v4/plumbing"
 )
@@ -18,30 +17,22 @@ func (g *Git) PreviousTag(currentHash plumbing.Hash) (*Tag, error) {
 	tags, err := g.getTags()
 
 	if err != nil {
-		if g.Debug {
-			log.Printf("[ERR] getting previous tag failed: %v", err)
-		}
+		g.DebugLogger.Printf("[ERR] getting previous tag failed: %v", err)
 		return nil, err
 	}
 
 	// If there are fewer than two tags assume that the currentCommit is the newest tag
 	if len(tags) < 2 {
-		if g.Debug {
-			log.Println("[ERR] previous tag not available")
-		}
+		g.DebugLogger.Println("[ERR] previous tag not available")
 		return nil, ErrPrevTagNotAvailable
 	}
 
 	if tags[0].Hash != currentHash {
-		if g.Debug {
-			log.Println("[ERR] current commit does not have a tag attached, building from this commit")
-		}
+		g.DebugLogger.Println("[ERR] current commit does not have a tag attached, building from this commit")
 		return tags[0], nil
 	}
 
-	if g.Debug {
-		log.Printf("success: previous tag found at %v", tags[1].Hash)
-	}
+	g.DebugLogger.Printf("success: previous tag found at %v", tags[1].Hash)
 
 	return tags[1], nil
 }

--- a/pkg/previous_tag_test.go
+++ b/pkg/previous_tag_test.go
@@ -1,6 +1,8 @@
 package history
 
 import (
+	"io/ioutil"
+	"log"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -9,7 +11,7 @@ import (
 
 func TestPreviousTag(t *testing.T) {
 	repo, _ := git.PlainOpen("../testdata/git_tags")
-	testGit := &Git{repo: repo, Debug: true}
+	testGit := &Git{repo: repo, DebugLogger: log.New(ioutil.Discard, "", 0)}
 
 	head, err := repo.Head()
 


### PR DESCRIPTION
BREAKING CHANGE: Debug flag is deprecated. DebugLogger is used instead. This allows consumers to use their own logger in this library.