### PR TITLE
refactor!: remove pkg folder

### DIFF
--- a/branch_diff_commits.go
+++ b/branch_diff_commits.go
@@ -1,4 +1,4 @@
-package history
+package git
 
 import (
 	"fmt"

--- a/branch_diff_commits_test.go
+++ b/branch_diff_commits_test.go
@@ -1,4 +1,4 @@
-package history
+package git
 
 import (
 	"testing"
@@ -23,7 +23,7 @@ func TestBranchDiffCommits(t *testing.T) {
 }
 
 func TestBranchDiffCommitsWithMasterMerge(t *testing.T) {
-	repo, _ := git.PlainOpen("../testdata/commits_on_branch")
+	repo, _ := git.PlainOpen("./testdata/commits_on_branch")
 	testGit := &Git{repo: repo}
 
 	commits, err := testGit.BranchDiffCommits("behind-master", "origin/master")

--- a/commit.go
+++ b/commit.go
@@ -1,4 +1,4 @@
-package history
+package git
 
 import (
 	"gopkg.in/src-d/go-git.v4/plumbing"

--- a/commit_date.go
+++ b/commit_date.go
@@ -1,4 +1,4 @@
-package history
+package git
 
 import (
 	"time"

--- a/commit_test.go
+++ b/commit_test.go
@@ -1,4 +1,4 @@
-package history
+package git
 
 import (
 	"io/ioutil"

--- a/commits_between.go
+++ b/commits_between.go
@@ -1,4 +1,4 @@
-package history
+package git
 
 import (
 	"errors"

--- a/commits_between_test.go
+++ b/commits_between_test.go
@@ -1,4 +1,4 @@
-package history
+package git
 
 import (
 	"io/ioutil"
@@ -11,7 +11,7 @@ import (
 )
 
 func TestCommitsBetween(t *testing.T) {
-	repo, _ := git.PlainOpen("../testdata/git_tags")
+	repo, _ := git.PlainOpen("./testdata/git_tags")
 	testGit := &Git{repo: repo, DebugLogger: log.New(ioutil.Discard, "", 0)}
 
 	head, err := repo.Head()

--- a/commits_on_branch.go
+++ b/commits_on_branch.go
@@ -1,4 +1,4 @@
-package history
+package git
 
 import (
 	"errors"

--- a/commits_on_branch_test.go
+++ b/commits_on_branch_test.go
@@ -1,4 +1,4 @@
-package history
+package git
 
 import (
 	"log"

--- a/current_branch.go
+++ b/current_branch.go
@@ -1,4 +1,4 @@
-package history
+package git
 
 import (
 	"gopkg.in/src-d/go-git.v4/plumbing"

--- a/current_branch_test.go
+++ b/current_branch_test.go
@@ -1,4 +1,4 @@
-package history
+package git
 
 import (
 	"testing"

--- a/current_commit.go
+++ b/current_commit.go
@@ -1,4 +1,4 @@
-package history
+package git
 
 import (
 	"gopkg.in/src-d/go-git.v4/plumbing/object"

--- a/current_commit_test.go
+++ b/current_commit_test.go
@@ -1,4 +1,4 @@
-package history
+package git
 
 import (
 	"io/ioutil"

--- a/current_tag.go
+++ b/current_tag.go
@@ -1,4 +1,4 @@
-package history
+package git
 
 import (
 	"errors"

--- a/current_tag_test.go
+++ b/current_tag_test.go
@@ -1,4 +1,4 @@
-package history
+package git
 
 import (
 	"io/ioutil"
@@ -9,7 +9,7 @@ import (
 )
 
 func TestCurrentTagHappy(t *testing.T) {
-	testGit, err := OpenGit("../testdata/git_tags", nil)
+	testGit, err := OpenGit("./testdata/git_tags", nil)
 
 	assert.NoError(t, err)
 
@@ -20,7 +20,7 @@ func TestCurrentTagHappy(t *testing.T) {
 }
 
 func TestCurrentTagAnnotatedHappy(t *testing.T) {
-	testGit, err := OpenGit("../testdata/annotated_git_tags_mix", nil)
+	testGit, err := OpenGit("./testdata/annotated_git_tags_mix", nil)
 
 	assert.NoError(t, err)
 

--- a/docs.go
+++ b/docs.go
@@ -1,2 +1,2 @@
 // Package history is a wrapper for Git actions. The main purpose is the unify some functionality in this package.
-package history
+package git

--- a/get_tags.go
+++ b/get_tags.go
@@ -1,4 +1,4 @@
-package history
+package git
 
 import (
 	"sort"

--- a/get_tags_test.go
+++ b/get_tags_test.go
@@ -1,4 +1,4 @@
-package history
+package git
 
 import (
 	"testing"
@@ -7,7 +7,7 @@ import (
 )
 
 func TestGetTags(t *testing.T) {
-	testGit, err := OpenGit("../testdata/git_tags", nil)
+	testGit, err := OpenGit("./testdata/git_tags", nil)
 
 	assert.NoError(t, err)
 
@@ -22,7 +22,7 @@ func TestGetTags(t *testing.T) {
 }
 
 func TestAnnotatedGetTags(t *testing.T) {
-	testGit, err := OpenGit("../testdata/annotated_git_tags_mix", nil)
+	testGit, err := OpenGit("./testdata/annotated_git_tags_mix", nil)
 
 	assert.NoError(t, err)
 

--- a/latest_commit_on_branch.go
+++ b/latest_commit_on_branch.go
@@ -1,4 +1,4 @@
-package history
+package git
 
 import (
 	"gopkg.in/src-d/go-git.v4/plumbing"

--- a/latest_commit_on_branch_test.go
+++ b/latest_commit_on_branch_test.go
@@ -1,4 +1,4 @@
-package history
+package git
 
 import (
 	"testing"

--- a/open_git.go
+++ b/open_git.go
@@ -1,4 +1,4 @@
-package history
+package git
 
 import (
 	"io/ioutil"

--- a/open_git_test.go
+++ b/open_git_test.go
@@ -1,4 +1,4 @@
-package history
+package git
 
 import (
 	"testing"
@@ -7,12 +7,12 @@ import (
 )
 
 func TestOpenGit(t *testing.T) {
-	_, err := OpenGit("../", nil)
+	_, err := OpenGit(".", nil)
 
 	// Should not error if this git repository is valid
 	assert.NoError(t, err)
 
-	_, unhappyErr := OpenGit(".", nil)
+	_, unhappyErr := OpenGit("./unknown", nil)
 
 	// Should error opening a folder with missing .git
 	assert.Error(t, unhappyErr)

--- a/previous_tag.go
+++ b/previous_tag.go
@@ -1,4 +1,4 @@
-package history
+package git
 
 import (
 	"errors"

--- a/previous_tag_test.go
+++ b/previous_tag_test.go
@@ -1,4 +1,4 @@
-package history
+package git
 
 import (
 	"io/ioutil"
@@ -10,7 +10,7 @@ import (
 )
 
 func TestPreviousTag(t *testing.T) {
-	repo, _ := git.PlainOpen("../testdata/git_tags")
+	repo, _ := git.PlainOpen("./testdata/git_tags")
 	testGit := &Git{repo: repo, DebugLogger: log.New(ioutil.Discard, "", 0)}
 
 	head, err := repo.Head()

--- a/tag.go
+++ b/tag.go
@@ -1,4 +1,4 @@
-package history
+package git
 
 import (
 	"time"


### PR DESCRIPTION
BREAKING CHANGE: Pkg folder does not make sense. It was previously used to hide away some config files, but it makes for annoying import paths